### PR TITLE
fix: Resolve Vercel deployment issues with Spotify ID architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a **Recall-Notes** music application with the following architecture:
 
-- **Frontend**: React 19 + TypeScript + Vite in the `recall-notes/` directory
+- **Frontend**: React 19 + TypeScript + Vite + React Router in the `recall-notes/` directory
 - **Backend**: Convex serverless backend for real-time data synchronization
 - **Database**: Convex database with predefined schema for users and playlists
+- **Deployment**: Configured for Vercel deployment
 
 The main application code is located in `recall-notes/` subdirectory, not the root.
+
+### Frontend Structure
+```
+src/
+├── components/          # Reusable UI components
+│   ├── Layout.tsx      # Main layout with navigation
+│   ├── SimpleLayout.tsx # Simplified layout for errors/loading
+│   ├── PlaylistForm.tsx # Add playlist form
+│   ├── PlaylistList.tsx # Display playlists
+│   ├── ErrorMessage.tsx # Error handling
+│   └── LoadingSpinner.tsx # Loading states
+├── pages/              # Route-based page components
+│   ├── HomePage.tsx    # Dashboard with recent playlists
+│   ├── PlaylistsPage.tsx # Full playlist management
+│   └── AddPlaylistPage.tsx # Add new playlist
+├── hooks/              # Custom React hooks
+│   └── useUser.ts      # User management logic
+└── types/              # TypeScript type definitions
+    └── index.ts        # Shared types
+```
 
 ## Key Commands
 
@@ -35,20 +56,41 @@ cd recall-notes
 
 ### Database Schema (convex/schema.ts)
 - **users table**: name, email, optional avatar/age/sex, favoriteArtist array
-- **playlists table**: title, artist, userId, spotifyId with indexes on userId and artist
+- **playlists table**: title, artist, userId, optional spotifyId with indexes on userId and artist
 
-### Convex Functions (convex/playlists.ts)
-- `getPlaylistsByUser(userId)` - Query to fetch user's playlists
-- `addPlaylist(title, artist, userId, spotifyId)` - Mutation to add new playlist
+### Convex Functions
+- **convex/users.ts**: User management (createUser, getUser)
+- **convex/playlists.ts**: Playlist operations
+  - `getPlaylistsByUser(userId)` - Query to fetch user's playlists
+  - `addPlaylist(title, artist, userId, spotifyId?)` - Mutation to add new playlist
 
-### Frontend Setup
-- **main.tsx**: Convex provider setup with environment variable `VITE_CONVEX_URL`
-- **App.tsx**: Currently basic Vite + React template (needs implementation)
+### Spotify Integration Strategy
+
+**Phase 1 (Current)**: Basic functionality without Spotify API
+- Simple form with title + artist only
+- Optional spotifyId field in database (prepared for future)
+- Focus on core playlist management
+
+**Phase 2 (Future)**: Spotify API integration
+- Automatic Spotify ID lookup using Spotify Web API Search
+- Rich track information (album art, preview URLs)
+- Enhanced user experience
+
+**Phase 3 (Future)**: Advanced features
+- 30-second preview playback
+- Related track recommendations
+- Playlist synchronization with Spotify
 
 ## Environment Configuration
 
-- Requires `.env.local` with `VITE_CONVEX_URL` for Convex backend connection
+### Local Development
+- `.env.local` with `VITE_CONVEX_URL` for Convex backend connection
 - Environment file exists but content is not tracked in git
+
+### Vercel Deployment
+Required environment variables:
+- `VITE_CONVEX_URL` - Convex deployment URL
+- Additional Convex production deployment setup required
 
 ## Development Notes
 
@@ -56,7 +98,27 @@ cd recall-notes
 - ESLint configured with React hooks and React refresh plugins
 - Project uses ES modules (`"type": "module"` in package.json)
 - Convex generates TypeScript definitions in `convex/_generated/`
+- React Router v7 for client-side routing
+- Modern CSS with responsive design
 
-## Current State
+## Current Implementation Status
 
-The application has backend infrastructure (Convex schema and functions) but the frontend is still the default Vite template. The core music playlist functionality is ready to be implemented in React components.
+✅ **Completed**:
+- Full component architecture with proper separation of concerns
+- React Router setup with multiple pages
+- User management with automatic test user creation
+- Playlist CRUD operations (Create, Read)
+- Responsive design with modern CSS
+- TypeScript type safety throughout
+- Build and deployment ready
+
+🚧 **Phase 1 Focus**:
+- Simple playlist management (title + artist)
+- Clean, intuitive user interface
+- Stable foundation for future Spotify integration
+
+📋 **Future Enhancements** (Phase 2+):
+- Spotify Web API integration
+- Automatic track ID resolution
+- Rich media features (album art, previews)
+- Playlist export/import functionality

--- a/recall-notes/convex/playlists.ts
+++ b/recall-notes/convex/playlists.ts
@@ -16,7 +16,7 @@ export const addPlaylist = mutation({
         title: v.string(),
         artist: v.string(),
         userId: v.id("users"),
-        spotifyId: v.string(),
+        spotifyId: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
         return await ctx.db.insert("playlists", args);

--- a/recall-notes/src/components/PlaylistForm.tsx
+++ b/recall-notes/src/components/PlaylistForm.tsx
@@ -13,8 +13,7 @@ interface PlaylistFormProps {
 export const PlaylistForm = ({ userId, onError, onSuccess }: PlaylistFormProps) => {
   const [formData, setFormData] = useState<PlaylistFormData>({
     title: '',
-    artist: '',
-    spotifyId: ''
+    artist: ''
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
   
@@ -32,22 +31,22 @@ export const PlaylistForm = ({ userId, onError, onSuccess }: PlaylistFormProps) 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     
-    if (!formData.title || !formData.artist || !formData.spotifyId) {
-      onError("すべてのフィールドを入力してください")
+    if (!formData.title || !formData.artist) {
+      onError("曲名とアーティスト名を入力してください")
       return
     }
 
     setIsSubmitting(true)
     try {
       await addPlaylist({
-        ...formData,
+        title: formData.title,
+        artist: formData.artist,
         userId
       })
       
       setFormData({
         title: '',
-        artist: '',
-        spotifyId: ''
+        artist: ''
       })
       
       onSuccess?.()
@@ -84,19 +83,6 @@ export const PlaylistForm = ({ userId, onError, onSuccess }: PlaylistFormProps) 
             value={formData.artist}
             onChange={handleInputChange('artist')}
             placeholder="アーティスト名を入力してください"
-            required
-            disabled={isSubmitting}
-          />
-        </div>
-        
-        <div className="form-group">
-          <label htmlFor="spotifyId">Spotify ID</label>
-          <input
-            id="spotifyId"
-            type="text"
-            value={formData.spotifyId}
-            onChange={handleInputChange('spotifyId')}
-            placeholder="Spotify IDを入力してください"
             required
             disabled={isSubmitting}
           />

--- a/recall-notes/src/components/PlaylistList.tsx
+++ b/recall-notes/src/components/PlaylistList.tsx
@@ -22,7 +22,9 @@ const PlaylistCard = ({ playlist }: PlaylistCardProps) => {
       <div className="playlist-info">
         <h3 className="playlist-title">{playlist.title}</h3>
         <p className="playlist-artist">by {playlist.artist}</p>
-        <p className="playlist-spotify">Spotify: {playlist.spotifyId}</p>
+        {playlist.spotifyId && (
+          <p className="playlist-spotify">Spotify: {playlist.spotifyId}</p>
+        )}
       </div>
       <div className="playlist-actions">
         <button className="play-btn" onClick={handlePlay}>

--- a/recall-notes/src/types/index.ts
+++ b/recall-notes/src/types/index.ts
@@ -17,11 +17,10 @@ export type Playlist = {
   title: string
   artist: string
   userId: string
-  spotifyId: string
+  spotifyId?: string
 }
 
 export type PlaylistFormData = {
   title: string
   artist: string
-  spotifyId: string
 }


### PR DESCRIPTION
- Make spotifyId optional throughout the codebase for TypeScript consistency
- Remove Spotify ID input from form UI for better UX (Phase 1 focus)
- Update Convex functions to handle optional spotifyId parameter
- Add conditional rendering for Spotify ID in playlist display
- Update documentation with 3-phase Spotify integration strategy

This resolves TypeScript compilation errors that were blocking Vercel deployment while maintaining extensibility for future Spotify API integration.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated documentation with expanded details on frontend structure, backend functions, deployment, Spotify integration strategy, and current implementation status.

* **Bug Fixes**
  * Playlist form no longer requires or displays a Spotify ID, simplifying playlist creation.

* **Refactor**
  * Made the Spotify ID field optional throughout the app, including input validation, type definitions, and playlist display logic. The form and types now only handle title and artist fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->