### PR TITLE
SpotifyAPIを用いた楽曲検索機能の実装

### DIFF
--- a/recall-notes/.env.example
+++ b/recall-notes/.env.example
@@ -1,0 +1,8 @@
+# Spotify API Credentials
+# To get these credentials:
+# 1. Go to https://developer.spotify.com/dashboard
+# 2. Create a new app
+# 3. Copy the Client ID and Client Secret
+
+VITE_SPOTIFY_CLIENT_ID=your_spotify_client_id_here
+VITE_SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here

--- a/recall-notes/convex/playlists.ts
+++ b/recall-notes/convex/playlists.ts
@@ -17,6 +17,10 @@ export const addPlaylist = mutation({
         artist: v.string(),
         userId: v.id("users"),
         spotifyId: v.optional(v.string()),
+        albumArt: v.optional(v.string()),
+        albumName: v.optional(v.string()),
+        albumId: v.optional(v.string()),
+        artistId: v.optional(v.string()),
     },
     handler: async (ctx, args) => {
         return await ctx.db.insert("playlists", args);

--- a/recall-notes/convex/schema.ts
+++ b/recall-notes/convex/schema.ts
@@ -16,6 +16,12 @@ export default defineSchema({
         artist: v.string(),
         userId: v.string(),
         spotifyId: v.optional(v.string()),
+        albumArt: v.optional(v.string()),
+        albumName: v.optional(v.string()),
+        albumId: v.optional(v.string()),
+        artistId: v.optional(v.string()),
     }).index("by_user", ["userId"])
-      .index("by_artist", ["artist"]),
+      .index("by_artist", ["artist"])
+      .index("by_album", ["albumId"])
+      .index("by_artist_id", ["artistId"]),
 });

--- a/recall-notes/src/components/SearchInput.tsx
+++ b/recall-notes/src/components/SearchInput.tsx
@@ -1,0 +1,188 @@
+import { useState, useRef, useEffect } from 'react'
+import { useSimpleSpotifySearch } from '../hooks/useSpotifySearch'
+import type { TrackSuggestion } from '../types/spotify'
+
+interface SearchInputProps {
+  placeholder?: string
+  onTrackSelect: (track: TrackSuggestion) => void
+  disabled?: boolean
+  className?: string
+  value?: string
+  onChange?: (value: string) => void
+  id?: string
+}
+
+export const SearchInput = ({
+  placeholder = "楽曲を検索...",
+  onTrackSelect,
+  disabled = false,
+  className = "",
+  value: controlledValue,
+  onChange: onControlledChange,
+  id
+}: SearchInputProps) => {
+  // 内部状態（非制御時）
+  const [internalValue, setInternalValue] = useState('')
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(-1)
+  
+  // 制御コンポーネントかどうかの判定
+  const isControlled = controlledValue !== undefined
+  const inputValue = isControlled ? controlledValue : internalValue
+  
+  // refs
+  const inputRef = useRef<HTMLInputElement>(null)
+  const suggestionsRef = useRef<HTMLDivElement>(null)
+  
+  // Spotify検索フック
+  const { suggestions, isLoading, error } = useSimpleSpotifySearch(inputValue)
+  
+  // 入力値変更ハンドラ
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+    
+    if (isControlled) {
+      onControlledChange?.(newValue)
+    } else {
+      setInternalValue(newValue)
+    }
+    
+    setShowSuggestions(true)
+    setSelectedIndex(-1)
+  }
+  
+  // 楽曲選択ハンドラ
+  const handleTrackSelect = (track: TrackSuggestion) => {
+    onTrackSelect(track)
+    setShowSuggestions(false)
+    setSelectedIndex(-1)
+    
+    // 入力欄に楽曲名 - アーティスト名を設定
+    const displayValue = `${track.name} - ${track.artist}`
+    if (isControlled) {
+      onControlledChange?.(displayValue)
+    } else {
+      setInternalValue(displayValue)
+    }
+  }
+  
+  // キーボードナビゲーション
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!showSuggestions || suggestions.length === 0) return
+    
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setSelectedIndex(prev => 
+          prev < suggestions.length - 1 ? prev + 1 : 0
+        )
+        break
+        
+      case 'ArrowUp':
+        e.preventDefault()
+        setSelectedIndex(prev => 
+          prev > 0 ? prev - 1 : suggestions.length - 1
+        )
+        break
+        
+      case 'Enter':
+        e.preventDefault()
+        if (selectedIndex >= 0 && selectedIndex < suggestions.length) {
+          handleTrackSelect(suggestions[selectedIndex])
+        }
+        break
+        
+      case 'Escape':
+        setShowSuggestions(false)
+        setSelectedIndex(-1)
+        break
+    }
+  }
+  
+  // 外部クリックで候補を非表示
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        inputRef.current && 
+        !inputRef.current.contains(event.target as Node) &&
+        suggestionsRef.current &&
+        !suggestionsRef.current.contains(event.target as Node)
+      ) {
+        setShowSuggestions(false)
+        setSelectedIndex(-1)
+      }
+    }
+    
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+  
+  return (
+    <div className={`search-input-container ${className}`}>
+      <div className="search-input-wrapper">
+        <input
+          ref={inputRef}
+          type="text"
+          id={id}
+          value={inputValue}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          onFocus={() => setShowSuggestions(true)}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="search-input"
+          autoComplete="off"
+        />
+        
+        {/* ローディングインジケーター */}
+        {isLoading && (
+          <div className="search-loading">
+            <div className="search-spinner"></div>
+          </div>
+        )}
+      </div>
+      
+      {/* 検索候補 */}
+      {showSuggestions && (suggestions.length > 0 || error) && (
+        <div ref={suggestionsRef} className="search-suggestions">
+          {error ? (
+            <div className="search-error">
+              <span>🚫 {error}</span>
+            </div>
+          ) : (
+            suggestions.map((track, index) => (
+              <div
+                key={track.id}
+                className={`search-suggestion-item ${
+                  index === selectedIndex ? 'selected' : ''
+                }`}
+                onClick={() => handleTrackSelect(track)}
+                onMouseEnter={() => setSelectedIndex(index)}
+              >
+                {/* アルバムアート */}
+                {track.albumArt && (
+                  <img 
+                    src={track.albumArt} 
+                    alt={`${track.name} album art`}
+                    className="suggestion-album-art"
+                  />
+                )}
+                
+                {/* 楽曲情報 */}
+                <div className="suggestion-info">
+                  <div className="suggestion-track-name">
+                    {track.name}
+                  </div>
+                  <div className="suggestion-artist-name">
+                    {track.artist}
+                  </div>
+                </div>
+                
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/recall-notes/src/hooks/useDebounce.ts
+++ b/recall-notes/src/hooks/useDebounce.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * スマートデバウンスフック
+ * 入力値を指定した遅延時間後に更新する
+ * 
+ * @param value - デバウンスしたい値
+ * @param delay - 遅延時間（ミリ秒）
+ * @returns デバウンスされた値
+ */
+export const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    // タイマーを設定
+    const timer = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    // クリーンアップ関数：前のタイマーをキャンセル
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}
+

--- a/recall-notes/src/hooks/useSpotifySearch.ts
+++ b/recall-notes/src/hooks/useSpotifySearch.ts
@@ -1,0 +1,126 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useDebounce } from './useDebounce'
+import { searchSpotifyTracks } from '../services/spotify'
+import { searchMockSpotifyTracks, hasSpotifyCredentials } from '../services/mockSpotify'
+import type { TrackSuggestion, SearchState } from '../types/spotify'
+
+/**
+ * Spotify楽曲検索のカスタムフック
+ * デバウンス機能とキャッシュ機能を内蔵
+ */
+export const useSpotifySearch = (
+  query: string,
+  options: {
+    debounceMs?: number
+    limit?: number
+    minQueryLength?: number
+    enableCache?: boolean
+  } = {}
+) => {
+  const {
+    debounceMs = 300,
+    limit = 10,
+    minQueryLength = 2,
+    enableCache = true
+  } = options
+
+  // 状態管理
+  const [searchState, setSearchState] = useState<SearchState>({
+    query: '',
+    suggestions: [],
+    isLoading: false,
+    error: null
+  })
+
+  // 簡単なキャッシュ実装
+  const [cache] = useState(() => new Map<string, TrackSuggestion[]>())
+
+  // デバウンスされたクエリ
+  const debouncedQuery = useDebounce(query.trim(), debounceMs)
+
+  // 検索実行関数
+  const executeSearch = useCallback(async (searchQuery: string) => {
+    if (searchQuery.length < minQueryLength) {
+      setSearchState(prev => ({
+        ...prev,
+        suggestions: [],
+        isLoading: false,
+        error: null
+      }))
+      return
+    }
+
+    // キャッシュチェック
+    if (enableCache && cache.has(searchQuery)) {
+      const cachedResults = cache.get(searchQuery)!
+      setSearchState(prev => ({
+        ...prev,
+        suggestions: cachedResults,
+        isLoading: false,
+        error: null
+      }))
+      return
+    }
+
+    // ローディング開始
+    setSearchState(prev => ({
+      ...prev,
+      isLoading: true,
+      error: null
+    }))
+
+    try {
+      // 環境変数が設定されていない場合はモックデータを使用
+      const results = hasSpotifyCredentials 
+        ? await searchSpotifyTracks(searchQuery, limit)
+        : await searchMockSpotifyTracks(searchQuery, limit)
+      
+      // キャッシュに保存
+      if (enableCache) {
+        cache.set(searchQuery, results)
+      }
+
+      setSearchState(prev => ({
+        ...prev,
+        suggestions: results,
+        isLoading: false,
+        error: null
+      }))
+
+    } catch (error) {
+      console.error('Search error:', error)
+      setSearchState(prev => ({
+        ...prev,
+        suggestions: [],
+        isLoading: false,
+        error: error instanceof Error ? error.message : '検索エラーが発生しました'
+      }))
+    }
+  }, [cache, enableCache, limit, minQueryLength])
+
+  // デバウンスされたクエリに基づいて検索実行
+  useEffect(() => {
+    if (debouncedQuery !== searchState.query) {
+      setSearchState(prev => ({ ...prev, query: debouncedQuery }))
+      executeSearch(debouncedQuery)
+    }
+  }, [debouncedQuery, executeSearch, searchState.query])
+
+  return {
+    // 検索結果と状態
+    suggestions: searchState.suggestions,
+    isLoading: searchState.isLoading,
+    error: searchState.error
+  }
+}
+
+/**
+ * より簡単な検索フック（基本機能のみ）
+ */
+export const useSimpleSpotifySearch = (query: string) => {
+  return useSpotifySearch(query, {
+    debounceMs: 300,
+    limit: 8,
+    minQueryLength: 2
+  })
+}

--- a/recall-notes/src/types/spotify.ts
+++ b/recall-notes/src/types/spotify.ts
@@ -1,0 +1,71 @@
+// Spotify API型定義
+export interface SpotifyImage {
+  height: number
+  url: string
+  width: number
+}
+
+export interface SpotifyArtist {
+  id: string
+  name: string
+  type: 'artist'
+  uri: string
+  href: string
+}
+
+export interface SpotifyAlbum {
+  id: string
+  name: string
+  images: SpotifyImage[]
+  release_date: string
+  type: 'album'
+}
+
+export interface SpotifyTrack {
+  id: string
+  name: string
+  artists: SpotifyArtist[]
+  album: SpotifyAlbum
+  duration_ms: number
+  popularity: number
+  preview_url: string | null
+  uri: string
+  href: string
+  type: 'track'
+}
+
+export interface SpotifySearchResponse {
+  tracks: {
+    href: string
+    items: SpotifyTrack[]
+    limit: number
+    offset: number
+    total: number
+    next: string | null
+    previous: string | null
+  }
+}
+
+// UI用の簡略化された楽曲情報
+export interface TrackSuggestion {
+  id: string
+  name: string
+  artist: string
+  albumArt?: string
+  previewUrl?: string
+}
+
+// 検索状態管理用
+export interface SearchState {
+  query: string
+  suggestions: TrackSuggestion[]
+  isLoading: boolean
+  error: string | null
+}
+
+// API設定
+export interface SpotifyConfig {
+  clientId: string
+  clientSecret: string
+  accessToken?: string
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a track search and autocomplete feature to the playlist form, allowing users to search for and select Spotify tracks with album art and artist details.
  * Manual entry for playlist title and artist is still supported alongside track selection.
  * Playlist creation now includes additional track-related data such as album art, album name, album ID, and artist ID.
* **Documentation**
  * Added an example environment configuration file with instructions for obtaining Spotify API credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->